### PR TITLE
Copying in some standard utilities: HTTP responses, grpc buffer connection for testing.

### DIFF
--- a/pkg/stdgrpc/buffernet/buffernet.go
+++ b/pkg/stdgrpc/buffernet/buffernet.go
@@ -1,0 +1,55 @@
+// Package buffernet provides facilities to establish a connection via grpc via internal buffers, allowing for testing
+// services and clients without worrying about real networks.
+package buffernet
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"net"
+)
+
+type BufferTransport struct {
+	Listener *bufconn.Listener
+}
+
+func New() *BufferTransport {
+	//buffer size defaults to 1 megabyte.  this should be sufficient for decently fast tests.
+	const bufSize = 1024 * 1024
+
+	var listener *bufconn.Listener
+	listener = bufconn.Listen(bufSize)
+
+	return &BufferTransport{
+		Listener: listener,
+	}
+}
+
+// Connect establishes a connection to the listening service via the buffer.  Will block until the connection is
+// established.
+func (b *BufferTransport) Connect(ctx context.Context) (conn *grpc.ClientConn, problem error) {
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return b.Listener.DialContext(ctx)
+	}
+	return grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(dialer), grpc.WithInsecure(), grpc.WithBlock())
+}
+
+func (b *BufferTransport) Listen(server *grpc.Server) error {
+	return server.Serve(b.Listener)
+}
+
+func (b *BufferTransport) ListenAsync(server *grpc.Server) (<-chan error, func()) {
+	result := make(chan error, 1)
+	serviceContext, done := context.WithCancel(context.Background())
+	go func() {
+		err := b.Listen(server)
+		result <- err
+		close(result)
+	}()
+	go func() {
+		<-serviceContext.Done()
+		server.GracefulStop()
+	}()
+
+	return result, done
+}

--- a/pkg/stdgrpc/buffernet/buffernet_test.go
+++ b/pkg/stdgrpc/buffernet/buffernet_test.go
@@ -1,0 +1,34 @@
+package buffernet
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+	"testing"
+)
+
+func TestBufferNet(t *testing.T) {
+	t.Run("Able to spawn a new service and client", func(t *testing.T) {
+		ctx, done := context.WithCancel(context.Background())
+		t.Cleanup(done)
+
+		healthService := health.NewServer()
+		healthService.SetServingStatus("test", healthgrpc.HealthCheckResponse_SERVING)
+
+		net := New()
+		server := grpc.NewServer()
+		healthgrpc.RegisterHealthServer(server, healthService)
+		_, shutdownServer := net.ListenAsync(server)
+		t.Cleanup(shutdownServer)
+
+		client, err := net.Connect(ctx)
+		require.NoError(t, err)
+		healthClient := healthgrpc.NewHealthClient(client)
+		out, err := healthClient.Check(ctx, &healthgrpc.HealthCheckRequest{Service: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, healthgrpc.HealthCheckResponse_SERVING, out.Status)
+	})
+}

--- a/pkg/stdhttp/stdhttp.go
+++ b/pkg/stdhttp/stdhttp.go
@@ -1,0 +1,75 @@
+// Package stdhttp provides utilities to simplify building HTTP and RESTful services.
+package stdhttp
+
+import (
+	"context"
+	"encoding/json"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"io"
+	"net/http"
+)
+
+// RespondString responds on the given response with the status code and text body.  If an error occurs while responding
+// it is journaled unless it is a client error.
+func RespondString(ctx context.Context, writer http.ResponseWriter, status int, body string) {
+	writer.WriteHeader(status)
+	if _, err := writer.Write([]byte(body)); err != nil {
+		span := trace.SpanFromContext(ctx)
+		span.SetStatus(codes.Error, "failed to write response")
+		span.AddEvent("failed to write response")
+		span.RecordError(err)
+	}
+}
+
+// InternalError provides the client with a 500 and a "Internal Error" response.
+func InternalError(writer http.ResponseWriter, request *http.Request, problem error) {
+	ctx := request.Context()
+
+	span := trace.SpanFromContext(ctx)
+	span.SetStatus(codes.Error, "internal server error")
+	span.RecordError(problem)
+
+	RespondString(ctx, writer, 500, "Internal error")
+}
+
+// ParseRequestEntity attempts to parse the request entity into the target entity.  True if successful, otherwise an
+// error is written to the response and false is returned.
+func ParseRequestEntity[E any](writer http.ResponseWriter, request *http.Request, entity *E) bool {
+	requestEntity, err := io.ReadAll(request.Body)
+	if err != nil {
+		ClientError(writer, request, err)
+		return false
+	}
+
+	if err := json.Unmarshal(requestEntity, entity); err != nil {
+		UnprocessableEntity(request.Context(), writer, err.Error())
+		return false
+	}
+	return true
+}
+
+func ClientError(writer http.ResponseWriter, request *http.Request, problem error) {
+	ctx := request.Context()
+	RespondString(ctx, writer, 400, "Client error")
+}
+
+func UnprocessableEntity(ctx context.Context, writer http.ResponseWriter, body string) {
+	RespondString(ctx, writer, 422, body)
+}
+
+// Ok writes a 200 Ok response and streams serialized JSON out.
+func Ok(writer http.ResponseWriter, request *http.Request, entity interface{}) {
+	ctx := request.Context()
+	//todo: encode to things other than JSON
+	header := writer.Header()
+	header.Add("Content-Type", "application/json")
+	writer.WriteHeader(200)
+
+	out := json.NewEncoder(writer)
+	if err := out.Encode(entity); err != nil {
+		span := trace.SpanFromContext(ctx)
+		span.SetStatus(codes.Error, "failed to encode JSON")
+		span.RecordError(err)
+	}
+}


### PR DESCRIPTION
Adds two utilities clusters:
* HTTP responses and JSON request parser at [pkg/stdhttp](pkg/stdhttp) 
* gRPC utility for connecting via the buffer utility.  Wraps it in a bow at [pkg/stdgrpc/buffernet](pkg/stdgrpc/buffernet)
